### PR TITLE
Update commonType module version to reflect its parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>org.connectopensource</groupId>
                 <artifactId>CONNECTCommonTypesLib</artifactId>
-                <version>4.3.0</version>
+                <version>4.4.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Use snapshot for development instead of release version.  Once we are ready, we will cut the release with correct version.

@jsmith2 can you please review?