### PR TITLE
Fix to use correct snapshot version instead of stable one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>org.connectopensource</groupId>
                 <artifactId>CONNECTCommonTypesLib</artifactId>
-                <version>4.3.0</version>
+                <version>4.4.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Use snapshot version instead of stable one.

@jsmith2 : can you please review this ?